### PR TITLE
Fix watch path for gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,8 +8,8 @@ var streamqueue  = require('streamqueue');
 
 
 var paths = {
-    scripts: ['assets/js/*/*.js'],
-    css: ['assets/css/*/*.css']
+    scripts: ['assets/js/*.js'],
+    css: ['assets/css/*.css']
 };
 
 // Not all tasks need to use streams


### PR DESCRIPTION
The watch path is slightly off so the watch task is not firing on the changes.