### PR TITLE
Fixed: auto exit on complete gulp tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,7 +39,11 @@ gulp.task('minify-css', function() {
     )
         .pipe(minifyCSS())
         .pipe(concat('all.min.css'))
-        .pipe(gulp.dest('assets/build'));
+        .pipe(gulp.dest('assets/build'))
+        .once('end', function(){
+            console.log('✓ Done!');
+            process.exit();
+        });
 });
 
 // Rerun the task when a file changes


### PR DESCRIPTION
Problem is, when I execute gulp tasks, it's finished but the process didn't exit.
So I did some research and found a trick. It seem to be a package bug.
Check it out: https://github.com/sindresorhus/gulp-mocha/issues/1#issuecomment-43454899
It's not a very big deal, I think, anyway, hope you consider my request.
